### PR TITLE
パッケージを一括でインストールする

### DIFF
--- a/Win11Setup/PackageInstall.ps1
+++ b/Win11Setup/PackageInstall.ps1
@@ -1,3 +1,10 @@
+# 実行中のスクリプトのパスを取得
+# REF: https://qiita.com/heignamerican/items/a81a1f4de3e34b28d836
+$scriptPath = $MyInvocation.MyCommand.Path
+$parentPath = Split-Path -Parent $scriptPath
+Set-Location -Path $parentPath
+$setupData = Get-Content -Path "..\data\install_list.json" | ConvertFrom-Json
+
 # 作業ディレクトリを保持しつつ管理者としてPowershellスクリプトを実行する
 # REF: https://www.delftstack.com/ja/howto/powershell/powershell-run-as-administrator/
 if (-Not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
@@ -7,5 +14,13 @@ if (-Not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdenti
     }
 }
 
-# winget install test
-winget install -e --id Microsoft.WindowsTerminal
+# 「パッケージをインストールする」と表示
+Write-Host "Installing packages..." -ForegroundColor Yellow
+
+# パッケージをインストールする
+foreach ($key in $setupData.Sources.Packages) {
+    $packageName = $key.PackageIdentifier
+    winget install -e --id $packageName
+}
+
+pause

--- a/data/install_list.json
+++ b/data/install_list.json
@@ -1,0 +1,59 @@
+{
+	"$schema" : "https://aka.ms/winget-packages.schema.2.0.json",
+	"CreationDate" : "2023-05-09T18:52:21.965-00:00",
+	"Sources" : 
+	[
+		{
+			"Packages" : 
+			[
+				{
+					"PackageIdentifier" : "AgileBits.1Password.Beta"
+				},
+				{
+					"PackageIdentifier" : "Canonical.Ubuntu.2204"
+				},
+				{
+					"PackageIdentifier" : "Microsoft.Edge.Dev"
+				},
+				{
+					"PackageIdentifier" : "Microsoft.EdgeWebView2Runtime"
+				},
+				{
+					"PackageIdentifier" : "Microsoft.PowerShell.Preview"
+				},
+				{
+					"PackageIdentifier" : "Microsoft.WindowsTerminal.Preview"
+				},
+				{
+					"PackageIdentifier" : "Notion.Notion"
+				}
+			],
+			"SourceDetails" : 
+			{
+				"Argument" : "https://cdn.winget.microsoft.com/cache",
+				"Identifier" : "Microsoft.Winget.Source_8wekyb3d8bbwe",
+				"Name" : "winget",
+				"Type" : "Microsoft.PreIndexed.Package"
+			}
+		},
+		{
+			"Packages" : 
+			[
+				{
+					"PackageIdentifier" : "XP8K17RNMM8MTN"
+				},
+				{
+					"PackageIdentifier" : "XP8LFCZM790F6B"
+				}
+			],
+			"SourceDetails" : 
+			{
+				"Argument" : "https://storeedgefd.dsx.mp.microsoft.com/v9.0",
+				"Identifier" : "StoreEdgeFD",
+				"Name" : "msstore",
+				"Type" : "Microsoft.Rest"
+			}
+		}
+	],
+	"WinGetVersion" : "1.4.10521"
+}


### PR DESCRIPTION
jsonファイルに出力したパッケージをwingetコマンドで一括インストールできる機能を追加
jsonファイルはwinget export -o コマンドで出力されたものを使いまわしている 